### PR TITLE
[cmake] Fix string parsing in fortran compiler flags

### DIFF
--- a/cmake/Modules/SetupF2Py.cmake
+++ b/cmake/Modules/SetupF2Py.cmake
@@ -73,12 +73,14 @@ find_program(F2PY_EXECUTABLE NAMES "f2py${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION
 
   # Set f2py compiler options: compiler vendor and path to Fortran77/90 compiler.
   if(F2PY_FCOMPILER)
-    set(_fcompiler_opts "--fcompiler=${F2PY_FCOMPILER}")
-    list(APPEND _fcompiler_opts "--f77exec=${CMAKE_Fortran_COMPILER}" "--f77flags='${CMAKE_Fortran_FLAGS} -DF2PY'")
+    string(REPLACE " " ";" CMAKE_Fortran_FLAGS_LST ${CMAKE_Fortran_FLAGS})
+    set(_fcompiler_opts --fcompiler=${F2PY_FCOMPILER})
+    list(APPEND _fcompiler_opts --f77exec=${CMAKE_Fortran_COMPILER} --f77flags="${CMAKE_Fortran_FLAGS_LST}" -DF2PY)
     if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
-      list(APPEND _fcompiler_opts "--f90exec=${CMAKE_Fortran_COMPILER}" "--f90flags='${CMAKE_Fortran_FLAGS} -DF2PY'")
+      list(APPEND _fcompiler_opts --f90exec=${CMAKE_Fortran_COMPILER} --f90flags="${CMAKE_Fortran_FLAGS_LST}" -DF2PY)
     endif(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
     if(USE_OPENMP)
-    list(APPEND _fcompiler_opts  "--f90flags='${CMAKE_Fortran_FLAGS} -DF2PY -fopenmp'")
+      list(APPEND CMAKE_Fortran_FLAGS -DF2PY -fopenmp)
+      list(APPEND _fcompiler_opts --f90flags="${CMAKE_Fortran_FLAGS_LST}")
     endif(USE_OPENMP)
   endif(F2PY_FCOMPILER)

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -46,10 +46,11 @@ endif()
   set( _name MAXENT )
   # Define the command to generate the Fortran to Python interface module. The
   # output will be a shared library that can be imported by python.
+  set(ADDITIONAL_OPTS -O3 -fPIC -DLAPACK77_Interface)
     add_custom_command(OUTPUT "${_name}${F2PY_SUFFIX}"
       COMMAND ${F2PY_EXECUTABLE} --quiet -m ${_name} #-c "${CMAKE_CURRENT_BINARY_DIR}/f2py-${_name}/${_name}.pyf"
               --build-dir "${CMAKE_Fortran_MODULE_DIRECTORY}"
-              ${_fcompiler_opts} --opt="-O3 -fPIC -DLAPACK77_Interface" -c ${_inc_opts}
+              ${_fcompiler_opts} --opt="${ADDITIONAL_OPTS}" -c ${_inc_opts}
                                  ${EXTERNAL_LIBRARIES}
                                 ${CMAKE_THREAD_LIBS_INIT} ${MAXENTF2PYOBJS} ${SRCMAXENT}/MaximumEntropy.F90
       DEPENDS ${SRCMAXENT}/MaximumEntropy.F90


### PR DESCRIPTION
The string parsing that happens in the add_custom_command for the
f2py call is very sensitive to strings containing spaces and leads
to problems on MacOS setups since spaces are escaped.
The fortran compiler flags should instead be gathered in a CMake List
(i.e. ';' seperated) and then expanded into a string.