### PR TITLE
[cmake] Do not move *.so files but copy them

### DIFF
--- a/src/ctqmc_fortran/CMakeLists.txt
+++ b/src/ctqmc_fortran/CMakeLists.txt
@@ -100,7 +100,7 @@ ENDIF(USE_NFFT AND NOT NFFT_FOUND)
   # CTQMC.so is generated in the source directory since f2py doesn't allow to specify the output directory of the object file.
   # Therefore we have to move it
   add_custom_command(TARGET ${_name} POST_BUILD 
-                    COMMAND ${CMAKE_COMMAND} -E rename
+                    COMMAND ${CMAKE_COMMAND} -E copy
                     ${SRCCTQMC}/${_name}${F2PY_SUFFIX} ${CMAKE_SOURCE_DIR}/auxiliaries/${_name}${F2PY_SUFFIX})
 
 

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
   # MAXENT.so is generated in the source directory since f2py doesn't allow to specify the output directory of the object file.
   # Therefore we have to move it
   add_custom_command(TARGET ${_name} POST_BUILD 
-                    COMMAND ${CMAKE_COMMAND} -E rename
+                    COMMAND ${CMAKE_COMMAND} -E copy
                     ${SRCMAXENT}/${_name}${F2PY_SUFFIX} ${CMAKE_SOURCE_DIR}/maxent/${_name}${F2PY_SUFFIX})
                     
   add_dependencies(${_name} MAXENTLIB)


### PR DESCRIPTION
Adjust the cmake such that *.so files are not moved but copied.
This guarantees that in two successive build stages you do not fail with error messages such as

```No rule to make target `../src/ctqmc_fortran/CTQMC.so', needed by `src/ctqmc_fortran/CMakeFiles/CTQMC'.  Stop.```