### PR TITLE
Spinflip Moves also in ferromagnetic case and their percentage increased.

### DIFF
--- a/src/ctqmc_fortran/CTQMC.F90
+++ b/src/ctqmc_fortran/CTQMC.F90
@@ -3729,10 +3729,10 @@ subroutine StepGlob()
    
 ! adding spin flip for paramagnetic case
    rand=grnd()
-   if(DTrace%ParaMag.eq.1.and.rand.lt.1d-1)then
+   if(rand.lt.4d-1)then
       move_type = 0
       call gen_SpinFlipUpdate(DTrace,DStates)
-   elseif(rand.lt.5d-1.and.get_Integer_Parameter("NSymMove").gt.0)then
+   elseif(rand.lt.7d-1.and.get_Integer_Parameter("NSymMove").gt.0)then
       move_type = 1
       call gen_SymUpdate(DTrace,DStates)
    else


### PR DESCRIPTION
For magnetism=ferro, no Spin-Flip moves were proposed. This is wrong, 
since in polarized systems the Markov Chain has to represent the "size" of 
polarized-up and polarized-down regions of the configuration space, and 
Spin-Flips are to move between them.