### PR TITLE
Various bug fixes (including incorrect sampling with 4-operator moves)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -34,11 +30,20 @@ jobs:
 
     - name: Configure
       if: matrix.python-version != '2.x'
-      run: cmake -B build
+      run: |
+        cmake -B build \
+              -DCMAKE_Fortran_COMPILER=gfortran-10 \
+              -DCMAKE_C_COMPILER=gcc-10 \
+              -DCMAKE_CXX_COMPILER=g++-10
 
     - name: Configure (use python2)
       if: matrix.python-version == '2.x'
-      run: cmake -B build -DPYTHON_EXECUTABLE=`which python2`
+      run: |
+        cmake -B build \
+              -DPYTHON_EXECUTABLE=`which python2` \
+              -DCMAKE_Fortran_COMPILER=gfortran-10 \
+              -DCMAKE_C_COMPILER=gcc-10 \
+              -DCMAKE_CXX_COMPILER=g++-10
 
     - name: Cache NFFT
       uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,12 @@ jobs:
 
     - name: Install required dependencies using brew
       if: matrix.os == 'macos-latest'
-      run: brew install openblas fftw hdf5
+      run: |
+        brew install openblas fftw hdf5
+        echo "LD_LIBRARY_PATH=$(brew --prefix)/opt/openblas:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "DYLD_LIBRARY_PATH=$(brew --prefix)/opt/openblas:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "BLAS_ROOT=$(brew --prefix)/opt/openblas" >> $GITHUB_ENV
+        echo "LAPACK_ROOT=$(brew --prefix)/opt/openblas" >> $GITHUB_ENV
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/cthyb
+++ b/cthyb
@@ -316,16 +316,12 @@ for iter_no in range(stat_iterations+worm_iterations):
             solver.set_problem(imp_problem, compute_fourpnt)
             result_gen, result_comp = solver.solve_comp_stats(iter_no, worm_sector, icomponent, mc_cfg_container)
 
-            #only write result if component returns ne 0
-            if (cfg["QMC"]["WormComponents"] or
-                    any(np.any(entry["value"])
-                        for key, entry in result_comp.other.items())):
+            # only write result if component-list is user-specified
+            # or when eta>0, i.e. the component exists
+            worm_eta = result_comp.other['worm-eta/{:05}'.format(icomponent)].mean()
+            if (cfg["QMC"]["WormComponents"] or np.amax(worm_eta) > 0.):
                 output.write_impurity_result(0, result_comp.other)
-                try:
-                    output.write_impurity_result(0, result_gen.other)
-                except OSError:
-                    sys.stderr.write(
-                        "\nWARNING: Ignoring auxiliary entries for multiple worm estimators.\n\n")
+                output.write_impurity_result(0, result_gen.other)
 
             log("Done with component {}".format(icomponent))
 

--- a/src/ctqmc_fortran/CMakeLists.txt
+++ b/src/ctqmc_fortran/CMakeLists.txt
@@ -42,7 +42,7 @@ Trace.F90
 ADD_LIBRARY(CTQMCLIB STATIC ${CTQMC_src})
 SET_PROPERTY(TARGET CTQMCLIB PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_target_properties(CTQMCLIB PROPERTIES COMPILE_FLAGS "-DLAPACK77_Interface")
-add_dependencies(CTQMCLIB mtrng)
+target_link_libraries(CTQMCLIB mtrng)
 
   set(_name CTQMC)
   set (CPPSTDLIBRARY "-lstdc++")#placeholder if we decide to better parse platforms in the future...
@@ -103,7 +103,9 @@ ENDIF(USE_NFFT AND NOT NFFT_FOUND)
   # Therefore we have to move it
   add_custom_command(TARGET ${_name} POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy
-                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}" "${CMAKE_SOURCE_DIR}/w2dyn/auxiliaries/${_name}${F2PY_SUFFIX}")
+                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}" "${CMAKE_SOURCE_DIR}/w2dyn/auxiliaries/${_name}${F2PY_SUFFIX}"
+		    COMMAND ${CMAKE_COMMAND} -E remove
+                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}")
 
 
 IF(WIN32)

--- a/src/ctqmc_fortran/CMakeLists.txt
+++ b/src/ctqmc_fortran/CMakeLists.txt
@@ -46,10 +46,6 @@ target_link_libraries(CTQMCLIB mtrng)
 
   set(_name CTQMC)
   set (CPPSTDLIBRARY "-lstdc++")#placeholder if we decide to better parse platforms in the future...
-  set(SWITCHES ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-  if(APPLE)
-    set(SWITCHES "--link-lapack_opt" "--link-fftw")
-  endif()
 
   # hack to not pass .dylib libraries directly because f2py does not
   # accept them as arguments, while it does accept .so ones...
@@ -78,6 +74,14 @@ target_link_libraries(CTQMCLIB mtrng)
     rephrase_dylib(NFFT_LIBRARIES "${NFFT_LIBRARIES}")
   endif ()
 
+  if (BLAS_LIBRARIES)
+    rephrase_dylib(BLAS_LIBRARIES "${BLAS_LIBRARIES}")
+  endif ()
+
+  if (LAPACK_LIBRARIES)
+    rephrase_dylib(LAPACK_LIBRARIES "${LAPACK_LIBRARIES}")
+  endif ()
+
   # Define the command to generate the Fortran to Python interface module. The
   # output will be a shared library that can be imported by python.
   add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}"
@@ -85,10 +89,9 @@ target_link_libraries(CTQMCLIB mtrng)
     COMMAND ${PYTHON_EXECUTABLE} -m numpy.f2py -c $<$<CONFIG:RELEASE>:--quiet> -m ${_name}
       --build-dir "${CMAKE_Fortran_MODULE_DIRECTORY}"
       ${_fcompiler_opts}
-      ${SWITCHES}
       ${LIB}/libmtrng.a
       ${CPPSTDLIBRARY}
-      ${CMAKE_THREAD_LIBS_INIT} ${_inc_opts} $<TARGET_LINKER_FILE:CTQMCLIB> ${NFFT_LIBRARIES} ${FFTW_LIBRARIES} ${SRCCTQMC}/CTQMC.F90
+      ${CMAKE_THREAD_LIBS_INIT} ${_inc_opts} $<TARGET_LINKER_FILE:CTQMCLIB> ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${NFFT_LIBRARIES} ${FFTW_LIBRARIES} ${SRCCTQMC}/CTQMC.F90
     DEPENDS "${SRCCTQMC}/CTQMC.F90" "${SRCCTQMC}/.f2py_f2cmap" CTQMCLIB
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "[F2PY] Building Fortran to Python interface module ${_name}")

--- a/src/ctqmc_fortran/CTQMC.F90
+++ b/src/ctqmc_fortran/CTQMC.F90
@@ -3732,8 +3732,13 @@ subroutine StepAdd4(Sector)
    BosTraceNew = get_BosonicTrace(DTrace,DStates)
    rand=grnd()
 
-   prob = abs(taudiff_factor * (2 * NBands)**4 * rempair_factor&
-              *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   if (b_offdiag) then
+      prob = abs(taudiff_factor * (2 * NBands)**4 * rempair_factor&
+           *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   else
+      prob = abs(taudiff_factor * (2 * NBands)**2 * rempair_factor&
+           *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   end if
 
    if(rand.lt.prob)then
 
@@ -4230,8 +4235,13 @@ subroutine StepRem4()
    TraceNew = get_trace_EB(DTrace,DStates)
    BosTraceNew = get_BosonicTrace(DTrace,DStates)
 
-   prob = abs(1_KINDR / real((2 * NBands)**4, KINDR) / taudiff_factor / rempair_factor&
-              *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   if (b_offdiag) then
+      prob = abs(1_KINDR / real((2 * NBands)**4, KINDR) / taudiff_factor / rempair_factor&
+           *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   else
+      prob = abs(1_KINDR / real((2 * NBands)**2, KINDR) / taudiff_factor / rempair_factor&
+           *wrat(TraceNew/DTrace%Trace, DetRat)*BosTraceNew/DTrace%BosonicTrace)
+   end if
 
    rand=grnd()
    if(rand.lt.prob)then

--- a/src/ctqmc_fortran/CTQMC.F90
+++ b/src/ctqmc_fortran/CTQMC.F90
@@ -222,7 +222,8 @@ implicit none
    class(TTrace), allocatable  :: DTrace
 
    integer, parameter :: GF4_IMAGTIME = 1, GF4_LEGENDRE = 2, GF4_MATSUBARA = 4, GF4_WORM = 8
-   integer            :: WormphConv,ZphConv,g4ph,g4pp,nfft_mode_g4iw
+   integer            :: WormphConv, ZphConv, g4ph, g4pp, nfft_mode_g4iw
+   integer            :: Nbatchsize_nfft_worm
    
    logical :: b_Eigenbasis, b_Densitymatrix,b_meas_susz,b_segment
    logical :: b_meas_susz_mat
@@ -355,7 +356,13 @@ subroutine init_CTQMC()
       else
          nfft_mode_g4iw = 0 ! 3D NFFT
       endif
-   endif
+
+  endif
+
+  if(PercentageWormInsert.gt.0) then
+      ! buffer size for the NFFT (for nfft g4iw)
+      Nbatchsize_nfft_worm = get_Integer_Parameter("Nbatchsize_nfft_worm")
+  endif
 
    if( IAND(FourPnt,GF4_WORM) /= 0 .and. get_integer_parameter("WormMeasH4iw") /= 0) then
       if(get_Integer_Parameter("WormPHConvention") /= 0) then
@@ -3625,6 +3632,9 @@ subroutine StepAdd4(Sector)
 
    NPairs_all = DTrace%NPairs
 
+   ! pairs for insertion were generated in ca order by pair_OperAdd,
+   ! but sorted in time-order by process_OperAdd, so it is not
+   ! sufficient to check 14 and 23
    if (is_rempair(DTrace, Oper(1)%p, Oper(4)%p)&
        .and. is_rempair(DTrace, Oper(2)%p, Oper(3)%p)) then
 
@@ -3654,6 +3664,44 @@ subroutine StepAdd4(Sector)
       call remove_Oper(DTrace, oplist)
       call update_NPairs(DTrace, oplist, -1)
       NPairs_only14 = DTrace%NPairs
+      call insert_Oper(DTrace, oplist)
+      DTrace%NPairs = NPairs_all
+
+      rempair_factor = (1_KINDR/real(NPairs_all, KINDR))&
+         * (1_KINDR/real(NPairs_only12, KINDR)&
+            + 1_KINDR/real(NPairs_only34, KINDR)&
+            + 1_KINDR/real(NPairs_only14, KINDR)&
+            + 1_KINDR/real(NPairs_only23, KINDR))
+
+      ! the insertion tau-choice factor depends on the position of the
+      ! annihilator of each pair relative to the window and especially
+      ! not on the order of the pairs, so it is the same for all four
+      ! possibilities; taudiff_factor is the inverse proposal
+      ! probability
+      taudiff_factor = taudiff_factor / 4_KINDR
+   else if (is_rempair(DTrace, Oper(1)%p, Oper(3)%p)&
+       .and. is_rempair(DTrace, Oper(2)%p, Oper(4)%p)) then
+
+      ! see above, but with diff. combination
+      if (Oper(1)%p%tau < Oper(3)%p%tau) then
+         oplist = (/Oper(1), Oper(3)/)
+      else
+         oplist = (/Oper(3), Oper(1)/)
+      end if
+      call remove_Oper(DTrace, oplist)
+      call update_NPairs(DTrace, oplist, -1)
+      NPairs_only23 = DTrace%NPairs  ! here actually only 24
+      call insert_Oper(DTrace, oplist)
+      DTrace%NPairs = NPairs_all
+
+      if (Oper(2)%p%tau < Oper(4)%p%tau) then
+         oplist = (/Oper(2), Oper(4)/)
+      else
+         oplist = (/Oper(4), Oper(2)/)
+      end if
+      call remove_Oper(DTrace, oplist)
+      call update_NPairs(DTrace, oplist, -1)
+      NPairs_only14 = DTrace%NPairs  ! here actually only 13
       call insert_Oper(DTrace, oplist)
       DTrace%NPairs = NPairs_all
 
@@ -8008,36 +8056,41 @@ subroutine init_solver(u_matrix_in,Ftau_full,muimp_full,&
 end subroutine init_solver
 
 !===============================================================================
-subroutine ctqmc_calibrate(Ncalibrate, list)
+subroutine ctqmc_calibrate(list, phase1pairnum, phase2taugrid, phase2pairnum, nprogress)
 !===============================================================================
-   use type_progress
+   logical, intent(in)        :: list
+   integer, intent(in)        :: phase1pairnum, phase2taugrid, phase2pairnum, nprogress
 
-!local
-   type(progress)             :: p
-   integer(c_int64_t)         :: i, Ncalibrate
-   logical                    :: list
+   integer(c_int64_t)         :: i
+   integer                    :: j, k, last_progress
    real(KINDR)                :: rand_num
    real(KINDR)                :: time_start, time_end
 
 
+
    if (list) then
-      if (.not. allocated(AccPairTau)) allocate(AccPairTau(1000))
+      if (.not. allocated(AccPairTau)) allocate(AccPairTau(phase1pairnum))
    else
       if (allocated(AccPairTau)) deallocate(AccPairTau)
       if (allocated(AccPair)) deallocate(AccPair)
-      allocate(AccPair(NBands, 2, 1000))
+      allocate(AccPair(NBands, 2, phase2taugrid))
       AccPair = 0
-      NAccPair = 1000
+      NAccPair = phase2taugrid
       AccPairMax = DTrace%taudiff_max
    end if
 
    call cpu_time(time_start)
 
-   p%adaptrate = 0.1
-   call pstart(p, int(Ncalibrate,PINT), &
-               title='WinCbr.' // simstr // ':', fancy=fancy_prog)
+   if (list) then
+      write (*, *) "Rank " // simstr // " starting window calibration phase 1"
+   else
+      write (*, *) "Rank " // simstr // " starting window calibration phase 2"
+   end if
 
-   do i = 1, Ncalibrate
+   i = 0
+   last_progress = 0
+   calibration_loop: do
+      i = i + 1
       if (any_signal_fired) exit
       rand_num = grnd()
       if (rand_num < (1.0_KINDR - PercentageTauShiftMove-PercentageGlobalMove)/2.0_KINDR) then
@@ -8067,8 +8120,29 @@ subroutine ctqmc_calibrate(Ncalibrate, list)
       else
          call StepShiftTau()
       end if
-      call ptick(p)
-   end do
+
+      if (modulo(i, min(1000, nprogress)) == 0) then
+         if (modulo(i, nprogress) <= last_progress) then
+            write (*, *) "Rank " // simstr // ": ", i, "steps"
+         end if
+         last_progress = modulo(i, nprogress)
+
+         if (list) then
+            if (apt_index > size(AccPairTau)) then
+               write (*, *) "Rank " // simstr // " window calibration phase 1 complete"
+               exit calibration_loop
+            end if
+         else
+            do j = 1, size(AccPair, dim=1)
+               do k = 1, size(AccPair, dim=2)
+                  if (sum(AccPair(j, k, :)) < phase2pairnum) cycle calibration_loop
+               end do
+            end do
+            write (*, *) "Rank " // simstr // " window calibration phase 2 complete"
+            exit calibration_loop
+         end if
+      end if
+   end do calibration_loop
 
    call cpu_time(time_end)
    time_calibration = time_calibration + (time_end - time_start)
@@ -8188,7 +8262,7 @@ subroutine ctqmc_worm_warmup(Nwarmups2,iSector,iComponent)
    !for component sampling, just add one additional sector
    if(iComponent.ne.0) then
       !bufferd transform for g4iw and h4iw
-      allocate(val_worm(5000000))
+      allocate(val_worm(Nbatchsize_nfft_worm))
       if(nfft_mode_g4iw .eq. 1) then
         allocate(val_worm_w(size(val_worm)))
       endif

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -56,7 +56,9 @@ endif()
   # Therefore we have to move it
   add_custom_command(TARGET ${_name} POST_BUILD 
                     COMMAND ${CMAKE_COMMAND} -E copy
-                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}" "${CMAKE_SOURCE_DIR}/w2dyn/maxent/${_name}${F2PY_SUFFIX}")
+                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}" "${CMAKE_SOURCE_DIR}/w2dyn/maxent/${_name}${F2PY_SUFFIX}"
+		    COMMAND ${CMAKE_COMMAND} -E remove
+                    "${CMAKE_CURRENT_BINARY_DIR}/${_name}${F2PY_SUFFIX}")
 
   add_dependencies(${_name} MAXENTLIB)
 

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -31,10 +31,34 @@ SET_PROPERTY(TARGET MAXENTLIB PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 set_target_properties(MAXENTLIB PROPERTIES COMPILE_FLAGS "-DLAPACK77_Interface")
 
+# hack to not pass .dylib libraries directly because f2py does not
+# accept them as arguments, while it does accept .so ones...
+function(rephrase_dylib TARGET_VAR LIBRARIES_STRING)
+  set(RESULT_LIST "")
+  foreach(entry ${LIBRARIES_STRING})
+    string(TOUPPER "${entry}" upcaseentry)
+    if(upcaseentry MATCHES "LIB([A-Za-z0-9_]*)\\.DYLIB$")
+      get_filename_component(entry_dir "${entry}" DIRECTORY)
+      string(LENGTH "${CMAKE_MATCH_1}" libname_length)
+      string(FIND "${upcaseentry}" "${CMAKE_MATCH_1}" libname_begin REVERSE)
+      string(SUBSTRING "${entry}" "${libname_begin}" "${libname_length}" libname)
+      list(APPEND RESULT_LIST "-L${entry_dir}" "-l${libname}")
+    else()
+      list(APPEND RESULT_LIST "${entry}")
+    endif()
+  endforeach()
+  set("${TARGET_VAR}" "${RESULT_LIST}" PARENT_SCOPE)
+endfunction()
+
+if (BLAS_LIBRARIES)
+  rephrase_dylib(BLAS_LIBRARIES "${BLAS_LIBRARIES}")
+endif ()
+
+if (LAPACK_LIBRARIES)
+  rephrase_dylib(LAPACK_LIBRARIES "${LAPACK_LIBRARIES}")
+endif ()
+
 set(EXTERNAL_LIBRARIES ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-if(APPLE)
-    set(EXTERNAL_LIBRARIES "--link-lapack_opt")
-endif()
 
   set( _name MAXENT )
   # Define the command to generate the Fortran to Python interface module. The

--- a/testsuite/ctqmc.tests/CMakeLists.txt
+++ b/testsuite/ctqmc.tests/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8.9)
-Project(ctqmc.tests Fortran)
+Project(ctqmc.tests Fortran CXX)
 find_package(PythonLibs REQUIRED)
 add_library(CTQMCMAIN STATIC ${SRCCTQMC}/CTQMC.F90)
 set_property(TARGET CTQMCMAIN PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(CTQMCMAIN CTQMCLIB)
 
 add_executable(1-get-MatFull 1-get-MatFull.F90)
 add_executable(2-time-evolve-in-eigenbasis 2-time-evolve-in-eigenbasis.F90)

--- a/testsuite/maxent.tests/CMakeLists.txt
+++ b/testsuite/maxent.tests/CMakeLists.txt
@@ -3,6 +3,7 @@ Project(maxent.tests Fortran)
 find_package(PythonLibs REQUIRED)
 add_library(MAXENTMAIN STATIC ${SRCMAXENT}/MaximumEntropy.F90)
 set_property(TARGET MAXENTMAIN PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(MAXENTMAIN MAXENTLIB)
 
 add_executable(1-getgridunit 1-getgridunit.F90)
 set (maxenttests 1-getgridunit)

--- a/testsuite/mtrng.tests/CMakeLists.txt
+++ b/testsuite/mtrng.tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.9)
-Project(mtrng.tests Fortran)
+Project(mtrng.tests Fortran CXX)
 
 add_executable(1-basic-call 1-basic-call.F90)
 set (mtrngtests 1-basic-call)

--- a/w2dyn/auxiliaries/__init__.py
+++ b/w2dyn/auxiliaries/__init__.py
@@ -21,5 +21,5 @@ BANNER = r"""
 
 CODE_VERSION = 1, 1, "1"
 CODE_VERSION_STRING = ".".join(map(str,CODE_VERSION))
-CODE_DATE = "January 2021"
+CODE_DATE = "February 2021"
 OUTPUT_VERSION = 2, 2

--- a/w2dyn/auxiliaries/__init__.py
+++ b/w2dyn/auxiliaries/__init__.py
@@ -19,7 +19,7 @@ BANNER = r"""
                                        Version %s, %s
 """
 
-CODE_VERSION = 1, 1, "0"
+CODE_VERSION = 1, 1, "1"
 CODE_VERSION_STRING = ".".join(map(str,CODE_VERSION))
-CODE_DATE = "June 2020"
+CODE_DATE = "January 2021"
 OUTPUT_VERSION = 2, 2

--- a/w2dyn/auxiliaries/config.py
+++ b/w2dyn/auxiliaries/config.py
@@ -5,7 +5,10 @@ from warnings import warn
 import os.path
 import sys
 import configobj
-import validate
+try:
+    import configobj.validate as validate
+except ImportError:
+    import validate
 import numpy as np
 import h5py as hdf5
 

--- a/w2dyn/auxiliaries/configspec
+++ b/w2dyn/auxiliaries/configspec
@@ -166,6 +166,7 @@ ZPHConvention         = integer(default=0)                  # flag to select bos
 G4ph                  = integer(default=1)                  # 1 -> do Fourier transform of g4iw-worm in ph channel
 G4pp                  = integer(default=0)                  # 1 -> do Fourier transform of g4iw-worm in pp channel
 nfft_mode_g4iw        = integer(default=0)  # 0: 3D NFFT.  1: 2D NFFT for each bosonic frequency
+Nbatchsize_nfft_worm  = integer(default=5000000)  # buffer size for NFFT
 
 # segment parameters
 segment=integer(default=0)
@@ -253,3 +254,4 @@ KListFile       = string (default=None)		# alternative filename for case.klist
 # GW              = integer(default=0)            # if GW=1 then a non-local GW self-energy is being read
 SGWnlFile       = string(default='S_GWnl.dat')  # file that contains the NON-LOCAL GW self-energy
 
+WriteOnlyQuant = force_list(default=None)

--- a/w2dyn/dmft/interaction.py
+++ b/w2dyn/dmft/interaction.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import, print_function, unicode_literals
 import numpy as np
-import scipy.misc as misc
+try:
+    from scipy.special import factorial
+except ImportError:
+    from scipy.misc import factorial
 import re
 import sys
 import w2dyn.dmft.dynamicalU as dynamicalU
@@ -311,7 +314,7 @@ class Coulomb(Interaction):
           if k1<m1 or k2<m2: continue
           # multiply by a factor F to account for all the ways
           # you can get there by applying the lowering operator
-          F = misc.factorial(k1-m1+k2-m2) / ( misc.factorial(k1-m1)*misc.factorial(k2-m2) )
+          F = factorial(k1-m1+k2-m2) / ( factorial(k1-m1) * factorial(k2-m2) )
           # Apply the lowering operators
           c1,c2,C = 1,1,1
           for k in np.arange(k1,m1,-1):


### PR DESCRIPTION
Fixes one bug causing incorrect sampling when four-operator moves are enabled (QMC.Percentage4OperatorMove > 0.0, non-default setting) and the hybridization is diagonal (QMC.offdiag = 0, default setting) and another bug causing incorrect sampling when four-operator moves are enabled.

To be merged after review.