### PR TITLE
fix removed np.int

### DIFF
--- a/Postproc/sigmaw.py
+++ b/Postproc/sigmaw.py
@@ -116,7 +116,7 @@ class wrapper_folding:
     """Consider only some bands and set rest of self-energies to small value"""
     def __init__(self, func, folding, const_sigmas):
         self.func = func
-        self.mapping = np.asarray(folding, dtype=np.int)
+        self.mapping = np.asarray(folding, dtype=int)
         self.const_sigmas = np.asarray(const_sigmas, dtype=np.cdouble)
         unique, inverse = np.unique(self.mapping, return_index=True)
         self.inv_mapping = inverse[(unique[0] == -1):]

--- a/w2dyn/auxiliaries/input.py
+++ b/w2dyn/auxiliaries/input.py
@@ -312,7 +312,7 @@ def read_hamiltonian(hk_file, spin_orbit=False):
     if header[0] == 'VERSION':
         warn("Version 2 headers are obsolete (specify in input file!)")
         nkpoints, natoms = map(int, nextline())
-        lines = np.array([nextline() for _ in range(natoms)], np.int)
+        lines = np.array([nextline() for _ in range(natoms)], int)
         nbands = np.sum(lines[:,:2])
         del lines, natoms
     elif len(header) != 3:

--- a/w2dyn/auxiliaries/quantities.py
+++ b/w2dyn/auxiliaries/quantities.py
@@ -21,7 +21,7 @@ def ineq_quantity(iter, qname, field=("value", "error"), ineq=None,
     if file_version is None:
         file_version = tuple(iter.parent.attrs["outfile-version"])
     try:
-        ineq = np.atleast_1d(np.asarray(ineq, dtype=np.int))
+        ineq = np.atleast_1d(np.asarray(ineq, dtype=int))
     except TypeError:
         if ineq is None: ineq = slice(None)
     if qname in iter:

--- a/w2dyn/dmft/doublecounting.py
+++ b/w2dyn/dmft/doublecounting.py
@@ -407,7 +407,7 @@ class Fixed_dp_Distance():
     a=0
     for a in range(0,natoms):
       for b in range(0,np.asarray(siw_dd).shape[2]):
-        idx = np.int(b + a*dc.shape[0]/natoms)
+        idx = int(b + a*dc.shape[0]/natoms)
         #print '              DC Bands:', idx, a
         dc[idx,0,idx,0] = siw_t2g_real_avg
         dc[idx,1,idx,1] = siw_t2g_real_avg

--- a/w2dyn/dmft/impurity.py
+++ b/w2dyn/dmft/impurity.py
@@ -70,10 +70,10 @@ class CtHybConfig:
             return cls(*solver.get_mc_config(noper))
         else:
             return cls(np.array((), dtype=np.double),
-                       np.array((), dtype=np.int),
-                       np.array((), dtype=np.int),
-                       np.array((), dtype=np.int),
-                       np.array((), dtype=np.int),
+                       np.array((), dtype=int),
+                       np.array((), dtype=int),
+                       np.array((), dtype=int),
+                       np.array((), dtype=int),
                        outer_sst, outer_state)
 
     def set_to_ctqmc(self, solver):
@@ -719,8 +719,8 @@ class CtHybSolver(ImpuritySolver):
             ctqmc.wormeta[:] = np.double(self.config['QMC']['WormEta'])
             max_iter = 50
             for i_try in range(max_iter):
-                steps_worm = np.array(0, dtype=np.int)
-                steps_z = np.array(0, dtype=np.int)
+                steps_worm = np.array(0, dtype=int)
+                steps_z = np.array(0, dtype=int)
                 ctqmc.count_steps(isector, icomponent, WormWarmups, steps_worm, steps_z)
                 if not (steps_worm + steps_z == WormWarmups):
                     raise ValueError('{} steps in worm, {} steps in Z, '
@@ -750,8 +750,8 @@ class CtHybSolver(ImpuritySolver):
                 to get the number of steps in Z and worm space
                 for a given eta. 
                 '''
-                steps_worm = np.array(0, dtype=np.int)
-                steps_z = np.array(0, dtype=np.int)
+                steps_worm = np.array(0, dtype=int)
+                steps_z = np.array(0, dtype=int)
                 ctqmc.wormeta[:] = eta # TODO: is it impossible to set a single array element?
                 ctqmc.count_steps(isector, icomponent, WormWarmups, steps_worm, steps_z)
                 if not (steps_worm + steps_z == WormWarmups):

--- a/w2dyn/dmft/selfcons.py
+++ b/w2dyn/dmft/selfcons.py
@@ -458,7 +458,7 @@ class DMFTStep:
 
             # GW Inclusion and Inclusion of GW 0th Moment  
             if (self.use_gw == 1) and (np.sum(self.siw_full) != 0):
-                norbitals_per_atom = np.int(self.lattice.norbitals/self.natoms)
+                norbitals_per_atom = int(self.lattice.norbitals/self.natoms)
                 orbits = slice( atom*norbitals_per_atom , (atom+1)*norbitals_per_atom )
                 # => Model based
                 if self.use_gw_kaverage == 0:    


### PR DESCRIPTION
Hi w2dynamics devs, 
Additionally to the recent commit a6ad6110f869a0b68336ef3514127e48e7b73b03 removing deprecated numpy data types float + complex, the recent numpy version 1.24 also removed np.int . It should be save to replace `np.int` with `int`. I did not touch the parts of the code that specifically ask for `np.int64` etc.