### PR TITLE
In cmake files use PROJECT_SOURCE_DIR over CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ endif(POLICY CMP0074)
 SET(VERSION 1.0)
 
 # Set the module path, so that CMake also considers our modules
-SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules/")
 
 # Uncomment if it is required that Fortran 90 is supported
 IF(NOT CMAKE_Fortran_COMPILER_SUPPORTS_F90)
@@ -187,9 +187,9 @@ endif()
 SET(CTQMCEXE ctqmc)
 
 # Define some directories
-SET(SRC ${CMAKE_SOURCE_DIR}/src)
+SET(SRC ${PROJECT_SOURCE_DIR}/src)
 SET(LIB ${CMAKE_CURRENT_BINARY_DIR}/lib)
-#SET(BIN ${CMAKE_SOURCE_DIR}/bin)
+#SET(BIN ${PROJECT_SOURCE_DIR}/bin)
 
 SET(SRCCTQMC ${SRC}/ctqmc_fortran)
 SET(SRCMAXENT ${SRC}/maxent)
@@ -207,7 +207,7 @@ ADD_SUBDIRECTORY(${SRCMAXENT})
 
 # Add a distclean target to the Makefile
 ADD_CUSTOM_TARGET(distclean 
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/distclean.cmake
+    COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/distclean.cmake
 )
 
 ADD_SUBDIRECTORY(testsuite/mtrng.tests)

--- a/PyCompileall.txt
+++ b/PyCompileall.txt
@@ -1,7 +1,7 @@
 if (PYTHON_VERSION_MAJOR GREATER 2)
   execute_process(COMMAND
-    ${PYTHON_EXECUTABLE} -m compileall ${CMAKE_SOURCE_DIR}/w2dyn)
+    ${PYTHON_EXECUTABLE} -m compileall ${PROJECT_SOURCE_DIR}/w2dyn)
 else ()
   execute_process(COMMAND
-    ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/testsuite/w2dyn.tests/compileall.py ${CMAKE_SOURCE_DIR}/w2dyn)
+    ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/testsuite/w2dyn.tests/compileall.py ${PROJECT_SOURCE_DIR}/w2dyn)
 endif()

--- a/src/ctqmc_fortran/CMakeLists.txt
+++ b/src/ctqmc_fortran/CMakeLists.txt
@@ -68,7 +68,7 @@ endif (USE_NFFT)
     COMPILE_OPTIONS $<$<AND:$<C_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,16>>:-Wno-error=incompatible-function-pointer-types>)
   target_link_libraries(${_name} PRIVATE fortranobject CTQMCLIB ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES} $<$<BOOL:${USE_NFFT}>:nfft>)
   add_custom_command(TARGET ${_name} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t "${CMAKE_SOURCE_DIR}/w2dyn/auxiliaries" $<TARGET_FILE:${_name}>
+    COMMAND ${CMAKE_COMMAND} -E copy -t "${PROJECT_SOURCE_DIR}/w2dyn/auxiliaries" $<TARGET_FILE:${_name}>
     COMMAND_EXPAND_LISTS)
 
 IF(WIN32)

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -53,7 +53,7 @@ set_target_properties(MAXENTLIB PROPERTIES COMPILE_FLAGS "-DLAPACK77_Interface")
     COMPILE_OPTIONS $<$<AND:$<C_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,16>>:-Wno-error=incompatible-function-pointer-types>)
   target_link_libraries(${_name} PRIVATE fortranobject MAXENTLIB ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
   add_custom_command(TARGET ${_name} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t "${CMAKE_SOURCE_DIR}/w2dyn/maxent" $<TARGET_FILE:${_name}>
+    COMMAND ${CMAKE_COMMAND} -E copy -t "${PROJECT_SOURCE_DIR}/w2dyn/maxent" $<TARGET_FILE:${_name}>
     COMMAND_EXPAND_LISTS)
 
 #####################################

--- a/testsuite/w2dyn.tests/CMakeLists.txt
+++ b/testsuite/w2dyn.tests/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(PythonInterp REQUIRED)
 enable_testing()
 if (PYTHON_VERSION_MAJOR GREATER 2)
   add_test(NAME 1-syntax_check
-    COMMAND ${PYTHON_EXECUTABLE} -m compileall ${CMAKE_SOURCE_DIR})
+    COMMAND ${PYTHON_EXECUTABLE} -m compileall ${PROJECT_SOURCE_DIR})
 else ()
   add_test(NAME 1-syntax_check
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/compileall.py ${CMAKE_SOURCE_DIR})
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/compileall.py ${PROJECT_SOURCE_DIR})
 endif()


### PR DESCRIPTION
These changes are relevant to allow building w2dynamics as a subproject, with e.g. [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html#id5)