### PR TITLE
[cmake] Fix issue where copy command failed for certain cmake versions

### DIFF
--- a/src/ctqmc_fortran/CMakeLists.txt
+++ b/src/ctqmc_fortran/CMakeLists.txt
@@ -68,7 +68,7 @@ endif (USE_NFFT)
     COMPILE_OPTIONS $<$<AND:$<C_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,16>>:-Wno-error=incompatible-function-pointer-types>)
   target_link_libraries(${_name} PRIVATE fortranobject CTQMCLIB ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES} $<$<BOOL:${USE_NFFT}>:nfft>)
   add_custom_command(TARGET ${_name} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t "${PROJECT_SOURCE_DIR}/w2dyn/auxiliaries" $<TARGET_FILE:${_name}>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${_name}> ${PROJECT_SOURCE_DIR}/w2dyn/auxiliaries/
     COMMAND_EXPAND_LISTS)
 
 IF(WIN32)

--- a/src/maxent/CMakeLists.txt
+++ b/src/maxent/CMakeLists.txt
@@ -53,7 +53,7 @@ set_target_properties(MAXENTLIB PROPERTIES COMPILE_FLAGS "-DLAPACK77_Interface")
     COMPILE_OPTIONS $<$<AND:$<C_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<C_COMPILER_VERSION>,16>>:-Wno-error=incompatible-function-pointer-types>)
   target_link_libraries(${_name} PRIVATE fortranobject MAXENTLIB ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
   add_custom_command(TARGET ${_name} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy -t "${PROJECT_SOURCE_DIR}/w2dyn/maxent" $<TARGET_FILE:${_name}>
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${_name}> ${PROJECT_SOURCE_DIR}/w2dyn/maxent/
     COMMAND_EXPAND_LISTS)
 
 #####################################


### PR DESCRIPTION
The post-build copy command failed for a Ubuntu 22.04 build with the message

```
Error: Target (for copy command) "/home/build/w2dynamics_interface/_deps/w2dynamics-build/src/ctqmc_fortran/CTQMC.cpython-310-x86_64-linux-gnu.so" is not a directory.
```

This PR fixes the problem.